### PR TITLE
Revert Softaculous Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Logs in to the VistaPanel control panel.
 
 Creates a new database.
 
-- `$dbname` (string): The name of the database.
+- `$dbname` (string): The name of the database, without the account prefix.
 
 #### `listDatabases()`
 
@@ -51,13 +51,13 @@ Returns an array of databases associated with the logged-in account.
 
 Deletes a database.
 
-- `$database` (string): The name of the database.
+- `$database` (string): The name of the database, without the account prefix.
 
 #### `getPhpmyadminLink($database)`
 
 Returns the phpMyAdmin link for a specific database.
 
-- `$database` (string): The name of the database.
+- `$database` (string): The name of the database, without the account prefix.
 
 #### `listDomains($option)`
 
@@ -96,11 +96,10 @@ Uploads an SSL certificate for a domain.
 #### `getSoftaculousLink()`
 
 Returns the Softaculous link for the control panel.
-##### NOTE: Some testing have been done, for me, the link doesn't return. However, it enables the Softaculous Account.
 
 #### `logout()`
 
-Logs out from the control panel.
+Logs out from the control panel, and resets client configuration.
 
 #### `approveNotification()`
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ Uploads an SSL certificate for a domain.
 - `$domainname` (string): The name of the domain.
 - `$cert` (string): The content of the SSL certificate file.
 
-#### `enableSoftaculous()`
+#### `getSoftaculousLink()`
 
-Enables Softaculous for the control panel.
+Returns the Softaculous link for the control panel.
+##### NOTE: Some testing have been done, for me, the link doesn't return. However, it enables the Softaculous Account.
 
 #### `logout()`
 

--- a/api-client.php
+++ b/api-client.php
@@ -385,7 +385,7 @@ class VistapanelApi
         return true;
     }
     
-    public function enableSoftaculous()
+    public function getSoftaculousLink()
     {
         $this->checkLogin();
         $getlink = $this->simpleCurl(
@@ -401,7 +401,7 @@ class VistapanelApi
         if (preg_match('~Location: (.*)~i', $getlink, $match)) {
             $location = trim($match[1]);
         }
-        return "Softaculous Enabled";
+        return $location;
     }
     
     public function logout()


### PR DESCRIPTION
The Softaculous functionality works perfectly (getSoftaculousLink returns the link correctly). 

An example usage with an account that isn't a new one (as I think that the issue might occur for accounts which haven't had their Softaculous activated yet) to verify this is the following:
```php
$api = new VistapanelApi();

$api->setCpanelUrl("vPanel URL");

$api->login("username", "password");
print_r($api->getSoftaculousLink());
```